### PR TITLE
Fix spaces in left and right always counting as indentation

### DIFF
--- a/src/data_reader.c
+++ b/src/data_reader.c
@@ -24,6 +24,7 @@ struct Line_Data* parse_line(const char* line){
 
     bool is_left = true;
     int left_length = 0;
+    int right_length = 0;
     int right_indentation = 0;
     
     for(int i=0; i<MAX_LINE_LENGTH; i++)
@@ -50,13 +51,14 @@ struct Line_Data* parse_line(const char* line){
         }
 
         if(isspace(currentChar)) {
-            if(is_left){
+            if(is_left && left_length == 0){
                 line_data->indentation++;
+                continue;
             }
-            else {
+            if(!is_left && right_length == 0){
                 right_indentation++;
+                continue;
             }
-            continue;
         }
 
         if(is_left)
@@ -68,6 +70,7 @@ struct Line_Data* parse_line(const char* line){
             // -1 to account for ':'
             int right_next_index = i - left_length - right_indentation - line_data->indentation - 1;
             line_data->right[right_next_index] = currentChar;
+            right_length++;
         }
     }
 

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -78,6 +78,25 @@ void test_read_ccd_file(){
     fclose(file);
 }
 
+void test_read_ccd_file_handle_spaces() {
+    FILE* file = tmpfile();
+
+    fputs("ver sion:0 .1", file);
+
+    rewind(file);
+
+    struct Line_Data_Node* lines = read_ccd_file(file);
+
+    CU_ASSERT_PTR_NOT_NULL(lines);
+    CU_ASSERT_PTR_NOT_NULL(lines->data);
+    CU_ASSERT(strcmp("ver sion", lines->data->left) == 0);
+    CU_ASSERT(strcmp("0 .1", lines->data->right) == 0);
+    CU_ASSERT(lines->data->indentation == 0);
+    printf("Indent: %d\n", lines->data->indentation);
+    CU_ASSERT_PTR_NULL(lines->next);
+}
+
 void add_data_reader_tests(CU_pSuite test_suite) {
     CU_ADD_TEST(test_suite, test_read_ccd_file);
+    CU_ADD_TEST(test_suite, test_read_ccd_file_handle_spaces);
 }


### PR DESCRIPTION
Closes #10 

Handles non-indent spaces on LHS and RHS. Right side is arguable as no RHS currently uses spaces but it may prevent config errors