### PR TITLE
Handle arbitrary line lengths

### DIFF
--- a/src/data_reader.c
+++ b/src/data_reader.c
@@ -14,11 +14,11 @@ void error_invalid_line(char* const reason_msg){
     exit(1);        
 }
 
-// Determine the length of a line by reading 128 character chunks
+// Determine the length of a line by reading 32 character chunks
 size_t get_line_length(FILE *file){
     int total_length = 0;
     int chunk_length = 0;
-    char buffer[128];
+    char buffer[32];
     bool is_done = false;
 
     do{
@@ -30,7 +30,7 @@ size_t get_line_length(FILE *file){
                 break;
             }
             chunk_length++;
-        } while(chunk_length < 128);
+        } while(chunk_length < 32);
 
         // Put back onto the input stream
         for(int i = chunk_length - 1; i > 0; i--)

--- a/src/data_reader.c
+++ b/src/data_reader.c
@@ -7,14 +7,44 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// TODO: Handle arbitrary line lengths
-size_t MAX_LINE_LENGTH = 100;
-
 // Simple error handler
 void error_invalid_line(char* const reason_msg){
     printf("Line is invalid\n");
     printf("%s\n", reason_msg);
     exit(1);        
+}
+
+// Determine the length of a line by reading 128 character chunks
+size_t get_line_length(FILE *file){
+    int total_length = 0;
+    int chunk_length = 0;
+    char buffer[128];
+    bool is_done = false;
+
+    do{
+        // Count number of characters
+        do{
+            buffer[chunk_length] = fgetc(file);       
+            if(feof(file) || buffer[chunk_length] != '\n' || buffer[chunk_length] != '\0'){
+                is_done = true;
+                break;
+            }
+            chunk_length++;
+        } while(chunk_length < 128);
+
+        // Put back onto the input stream
+        for(int i = chunk_length - 1; i > 0; i--)
+        {
+            ungetc(buffer[i], file);
+        }
+
+        total_length += chunk_length;
+        fseek(file, chunk_length, SEEK_CUR); // Make sure we don't read the same part repeatedly
+        chunk_length = 0;
+    } while(!is_done);
+
+    fseek(file, -total_length, SEEK_CUR); // Roll back the file pointer for the parser
+    return total_length;
 }
 
 // Parses the left side of a line. The result is stored in result. Moves line up to the first ':'. Return the amount of indentation
@@ -27,10 +57,6 @@ int parse_left(const char** line, char** result) {
         while(**line == ' ' && nextIndex == 0){
             indent++;
             (*line)++;
-        }
-
-        if(nextIndex >= MAX_LINE_LENGTH) {
-            error_invalid_line("Exceeded max line length");
         }
 
         char currentChar = **line;
@@ -80,7 +106,7 @@ void parse_right(const char** line, char** result) {
 }
 
 // Parse a single line (left to right)
-struct Line_Data* parse_line(const char* line){
+struct Line_Data* parse_line(const char* line, const size_t line_length){
     /*
      * A line is one of:
      * - Whitespace (ignore)
@@ -90,8 +116,8 @@ struct Line_Data* parse_line(const char* line){
      * - An error (raise)
      */
     struct Line_Data* line_data = (struct Line_Data*)calloc(1, sizeof(struct Line_Data));
-    line_data->left = (char*)calloc(MAX_LINE_LENGTH, sizeof(char));
-    line_data->right = (char*)calloc(MAX_LINE_LENGTH,sizeof(char));
+    line_data->left = (char*)calloc(line_length, sizeof(char));
+    line_data->right = (char*)calloc(line_length,sizeof(char));
 
     line_data->indentation = parse_left(&line, &line_data->left);
     line++; //Line comes back from parse_left pointing at ':'
@@ -104,14 +130,17 @@ struct Line_Data* parse_line(const char* line){
 
 // Parse a file (top to bottom)
 struct Line_Data_Node* read_ccd_file(FILE *file) {
-    char* current_line = (char *)calloc(MAX_LINE_LENGTH, sizeof(char));
+    char* current_line;
+    size_t line_length;
     struct Line_Data_Node* line_data_list = NULL;
 
     long chars_read;
     int lines_read = 0;
 
     do{
-        chars_read = getline(&current_line, &MAX_LINE_LENGTH, file);
+        line_length = get_line_length(file);
+        current_line = (char *)calloc(line_length, sizeof(char)); // DEALLOC////////////////////////////////////////////////////////////////////////
+        chars_read = getline(&current_line, &line_length, file);
         if (chars_read <= 0){
             if(lines_read == 0){
                 goto empty_file;
@@ -133,18 +162,13 @@ struct Line_Data_Node* read_ccd_file(FILE *file) {
             continue;
         }
 
-        if (chars_read == MAX_LINE_LENGTH)
-        {
-            error_invalid_line("Line longer than max permitted");
-        }
-
         // Last line of file won't have a new line
         if (*(current_line + chars_read -1) != '\n')
         {
             *(current_line + chars_read) = '\n';
         }
         
-        line_data_list = append_line_data(line_data_list, parse_line(current_line));
+        line_data_list = append_line_data(line_data_list, parse_line(current_line, line_length));
 
     }while(chars_read != -1);
     goto success;

--- a/src/data_reader.c
+++ b/src/data_reader.c
@@ -15,25 +15,29 @@ void error_invalid_line(char* const reason_msg){
 }
 
 // Determine the length of a line by reading 32 character chunks
-size_t get_line_length(FILE *file){
+size_t get_line_length(FILE *file, size_t* left_length, size_t* right_length){
     int total_length = 0;
     int chunk_length = 0;
     char buffer[32];
     bool is_done = false;
+    bool colon_seen = false;
+    bool is_left = true;
 
     do{
         // Count number of characters
         do{
             buffer[chunk_length] = fgetc(file);       
-            if(feof(file) || buffer[chunk_length] != '\n' || buffer[chunk_length] != '\0'){
+            if(feof(file) || buffer[chunk_length] == '\n' || buffer[chunk_length] == '\0'){
                 is_done = true;
-                break;
+            }
+            if(buffer[chunk_length] == ':'){ // Test for colon (switch to counting right side)
+                colon_seen = true;
             }
             chunk_length++;
-        } while(chunk_length < 32);
+        } while(chunk_length < 32 && !is_done && !colon_seen);
 
         // Put back onto the input stream
-        for(int i = chunk_length - 1; i > 0; i--)
+        for(int i = chunk_length - 1; i > -1; i--)
         {
             ungetc(buffer[i], file);
         }
@@ -41,8 +45,22 @@ size_t get_line_length(FILE *file){
         total_length += chunk_length;
         fseek(file, chunk_length, SEEK_CUR); // Make sure we don't read the same part repeatedly
         chunk_length = 0;
+
+        // Switch to counting right side
+        if(colon_seen){
+            if(!is_left){
+                error_invalid_line("Found ':' on right side of declaration");
+            }
+            if(total_length == 1){
+                error_invalid_line("Left is empty");
+            }
+            *left_length = total_length;
+            is_left = false;
+            colon_seen = false;
+        }
     } while(!is_done);
 
+    *right_length = total_length - *left_length;
     fseek(file, -total_length, SEEK_CUR); // Roll back the file pointer for the parser
     return total_length;
 }
@@ -106,7 +124,7 @@ void parse_right(const char** line, char** result) {
 }
 
 // Parse a single line (left to right)
-struct Line_Data* parse_line(const char* line, const size_t line_length){
+struct Line_Data* parse_line(const char* line, const size_t LEFT_LENGTH, const size_t RIGHT_LENGTH){
     /*
      * A line is one of:
      * - Whitespace (ignore)
@@ -116,8 +134,8 @@ struct Line_Data* parse_line(const char* line, const size_t line_length){
      * - An error (raise)
      */
     struct Line_Data* line_data = (struct Line_Data*)calloc(1, sizeof(struct Line_Data));
-    line_data->left = (char*)calloc(line_length, sizeof(char));
-    line_data->right = (char*)calloc(line_length,sizeof(char));
+    line_data->left = (char*)calloc(LEFT_LENGTH, sizeof(char));
+    line_data->right = (char*)calloc(RIGHT_LENGTH,sizeof(char));
 
     line_data->indentation = parse_left(&line, &line_data->left);
     line++; //Line comes back from parse_left pointing at ':'
@@ -130,16 +148,16 @@ struct Line_Data* parse_line(const char* line, const size_t line_length){
 
 // Parse a file (top to bottom)
 struct Line_Data_Node* read_ccd_file(FILE *file) {
-    char* current_line;
-    size_t line_length;
+    char* current_line = (char *)calloc(1, sizeof(char));
     struct Line_Data_Node* line_data_list = NULL;
 
     long chars_read;
     int lines_read = 0;
 
     do{
-        line_length = get_line_length(file);
-        current_line = (char *)calloc(line_length, sizeof(char)); // DEALLOC////////////////////////////////////////////////////////////////////////
+        size_t left_length, right_length;
+        size_t line_length = get_line_length(file, &left_length, &right_length);
+        current_line = (char *)realloc(current_line, line_length * sizeof(char));
         chars_read = getline(&current_line, &line_length, file);
         if (chars_read <= 0){
             if(lines_read == 0){
@@ -168,7 +186,7 @@ struct Line_Data_Node* read_ccd_file(FILE *file) {
             *(current_line + chars_read) = '\n';
         }
         
-        line_data_list = append_line_data(line_data_list, parse_line(current_line, line_length));
+        line_data_list = append_line_data(line_data_list, parse_line(current_line, left_length, right_length));
 
     }while(chars_read != -1);
     goto success;

--- a/src/data_reader.c
+++ b/src/data_reader.c
@@ -21,7 +21,6 @@ size_t get_line_length(FILE *file, size_t* left_length, size_t* right_length){
     char buffer[32];
     bool is_done = false;
     bool colon_seen = false;
-    bool is_left = true;
 
     do{
         // Count number of characters
@@ -46,16 +45,9 @@ size_t get_line_length(FILE *file, size_t* left_length, size_t* right_length){
         fseek(file, chunk_length, SEEK_CUR); // Make sure we don't read the same part repeatedly
         chunk_length = 0;
 
-        // Switch to counting right side
-        if(colon_seen){
-            if(!is_left){
-                error_invalid_line("Found ':' on right side of declaration");
-            }
-            if(total_length == 1){
-                error_invalid_line("Left is empty");
-            }
+        // Switch to counting right side upon first colon
+        if(colon_seen && *left_length == 0){
             *left_length = total_length;
-            is_left = false;
             colon_seen = false;
         }
     } while(!is_done);
@@ -148,14 +140,14 @@ struct Line_Data* parse_line(const char* line, const size_t LEFT_LENGTH, const s
 
 // Parse a file (top to bottom)
 struct Line_Data_Node* read_ccd_file(FILE *file) {
-    char* current_line = (char *)calloc(1, sizeof(char));
+    char* current_line = NULL;
     struct Line_Data_Node* line_data_list = NULL;
 
     long chars_read;
     int lines_read = 0;
 
     do{
-        size_t left_length, right_length;
+        size_t left_length = 0, right_length = 0;
         size_t line_length = get_line_length(file, &left_length, &right_length);
         current_line = (char *)realloc(current_line, line_length * sizeof(char));
         chars_read = getline(&current_line, &line_length, file);
@@ -184,6 +176,10 @@ struct Line_Data_Node* read_ccd_file(FILE *file) {
         if (*(current_line + chars_read -1) != '\n')
         {
             *(current_line + chars_read) = '\n';
+        }
+
+        if(line_length == 1){
+            error_invalid_line("Left is empty");
         }
         
         line_data_list = append_line_data(line_data_list, parse_line(current_line, left_length, right_length));

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -157,16 +157,16 @@ void test_arbitrary_line_lengths(){
 
     fputs("short left:short right\n", file);
     // "a...a:short right"
-    fputs(long_string, file);
+    fputs(*long_string, file);
     fputs(":short right\n", file);
     // "short left:a...a"
     fputs("short left:", file);
-    fputs(long_string, file);
+    fputs(*long_string, file);
     fputs("\n", file);
     // "a...a:a...a"
-    fputs(long_string, file);
+    fputs(*long_string, file);
     fputs(":", file);
-    fputs(long_string, file);
+    fputs(*long_string, file);
     fputs("\n", file);
     
     rewind(file);
@@ -178,13 +178,13 @@ void test_arbitrary_line_lengths(){
     test_line(__func__, __LINE__, lines, "short left", "short right", 0);
     lines = lines->next;
 
-    test_line(__func__, __LINE__, lines, long_string, "short right", 0);
+    test_line(__func__, __LINE__, lines, *long_string, "short right", 0);
     lines = lines->next;
 
-    test_line(__func__, __LINE__, lines, "short left", long_string, 0);
+    test_line(__func__, __LINE__, lines, "short left", *long_string, 0);
     lines = lines->next;
 
-    test_line(__func__, __LINE__, lines, long_string, long_string, 0);
+    test_line(__func__, __LINE__, lines, *long_string, *long_string, 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -141,9 +141,40 @@ void test_trailing_whitespace_is_trimmed(){
     fclose(file);
 }
 
+void test_arbitrary_line_lengths(){
+    FILE* file = tmpfile();
+
+    fputs("short left:short right\n", file);
+    fputs("I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so:short right\n", file);
+    fputs("short left:I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths\n", file);
+    fputs("I'm not going to be as long as my friend two lines above, but I will be quite long:As I use the other side of the colon to continue to be a very very long line overall\n", file);
+
+    rewind(file);
+
+    struct Line_Data_Node* lines = read_ccd_file(file);
+
+    printf("Beginning asserts\n");
+    test_line(lines, "short left", "short right", 0);
+    lines = lines->next;
+
+    test_line(lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
+    lines = lines->next;
+
+    test_line(lines, "short left", "I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths", 0);
+    lines = lines->next;
+
+    test_line(lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
+    CU_ASSERT_PTR_NULL(lines->next);
+
+    delete_list(lines);
+
+    fclose(file);
+}
+
 void add_data_reader_tests(CU_pSuite test_suite) {
     CU_ADD_TEST(test_suite, test_read_ccd_file);
     CU_ADD_TEST(test_suite, test_read_ccd_file_handle_spaces);
     CU_ADD_TEST(test_suite, test_read_ccd_file_lowercase_left);
     CU_ADD_TEST(test_suite, test_trailing_whitespace_is_trimmed);
+    CU_ADD_TEST(test_suite, test_arbitrary_line_lengths);
 }

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -10,6 +10,7 @@
 // Generic function to test a whole line
 void test_line(char source_line[], struct Line_Data_Node* lines, char expected_left[], char expected_right[], int expected_indentation){
     printf("%s\n", source_line); // The generic function is too abstract without this
+    printf("%s --- %s\n", lines->data->left, lines->data->right);
     CU_ASSERT_PTR_NOT_NULL(lines);
     CU_ASSERT_PTR_NOT_NULL(lines->data);
     CU_ASSERT(strcmp(lines->data->left, expected_left) == 0);
@@ -158,13 +159,13 @@ void test_arbitrary_line_lengths(){
     test_line("Arbitrary Length 0", lines, "short left", "short right", 0);
     lines = lines->next;
 
-    //test_line("Arbitrary Length 1", lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
+    test_line("Arbitrary Length 1", lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
     lines = lines->next;
 
     test_line("Arbitrary Length 2", lines, "short left", "I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths", 0);
     lines = lines->next;
 
-    //test_line("Arbitrary Length 3", lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
+    test_line("Arbitrary Length 3", lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -10,7 +10,6 @@
 // Generic function to test a whole line
 void test_line(char source_line[], struct Line_Data_Node* lines, char expected_left[], char expected_right[], int expected_indentation){
     printf("%s\n", source_line); // The generic function is too abstract without this
-    printf("%s --- %s\n", lines->data->left, lines->data->right);
     CU_ASSERT_PTR_NOT_NULL(lines);
     CU_ASSERT_PTR_NOT_NULL(lines->data);
     CU_ASSERT(strcmp(lines->data->left, expected_left) == 0);
@@ -147,25 +146,26 @@ void test_arbitrary_line_lengths(){
     FILE* file = tmpfile();
 
     fputs("short left:short right\n", file);
-    fputs("I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so:short right\n", file);
-    fputs("short left:I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths\n", file);
-    fputs("I'm not going to be as long as my friend two lines above, but I will be quite long:As I use the other side of the colon to continue to be a very very long line overall\n", file);
+    fputs("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:short right\n", file);
+    fputs("short left:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n", file);
+    fputs("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n", file);
 
     rewind(file);
 
     struct Line_Data_Node* lines = read_ccd_file(file);
 
+    // Remember, left side will be lowercase
     printf("Beginning asserts\n");
     test_line("Arbitrary Length 0", lines, "short left", "short right", 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 1", lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
+    test_line("Arbitrary Length 1", lines, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "short right", 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 2", lines, "short left", "I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths", 0);
+    test_line("Arbitrary Length 2", lines, "short left", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 3", lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
+    test_line("Arbitrary Length 3", lines, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -7,14 +7,21 @@
 #include <stdio.h>
 #include <string.h>
 
+int known_failed_tests = 0;
+int* failed_tests_ptr;
+
 // Generic function to test a whole line
-void test_line(char source_line[], struct Line_Data_Node* lines, char expected_left[], char expected_right[], int expected_indentation){
-    printf("%s\n", source_line); // The generic function is too abstract without this
+void test_line(const char source_func[], const int source_line, struct Line_Data_Node* lines, char expected_left[], char expected_right[], int expected_indentation){
     CU_ASSERT_PTR_NOT_NULL(lines);
     CU_ASSERT_PTR_NOT_NULL(lines->data);
     CU_ASSERT(strcmp(lines->data->left, expected_left) == 0);
     CU_ASSERT(strcmp(lines->data->right, expected_right) == 0);
     CU_ASSERT(lines->data->indentation == expected_indentation);
+
+    if(*failed_tests_ptr > known_failed_tests){
+        printf("FAIL OCCURRED - Called in %s - On line %d\n", source_func, source_line);
+        known_failed_tests++; // Allows for multiple tests to be caught
+    }
 }
 
 void test_read_ccd_file(){
@@ -33,22 +40,22 @@ void test_read_ccd_file(){
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     printf("Beginning asserts\n");
-    test_line("Read CCD File 0", lines, "version", "0.1", 0);
+    test_line(__func__, __LINE__, lines, "version", "0.1", 0);
     lines = lines->next;
 
-    test_line("Read CCD File 1", lines, "type", "class", 0);
+    test_line(__func__, __LINE__, lines, "type", "class", 0);
     lines = lines->next;
 
-    test_line("Read CCD File 2", lines, "name", "test", 0);
+    test_line(__func__, __LINE__, lines, "name", "test", 0);
     lines = lines->next;
 
-    test_line("Read CCD File 3", lines, "fields", "", 0);
+    test_line(__func__, __LINE__, lines, "fields", "", 0);
     lines = lines->next;
 
-    test_line("Read CCD File 4", lines, "test_field", "", 4);
+    test_line(__func__, __LINE__, lines, "test_field", "", 4);
     lines = lines->next;
 
-    test_line("Read CCD File 5", lines, "type", "int32", 8);
+    test_line(__func__, __LINE__, lines, "type", "int32", 8);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);
@@ -65,7 +72,7 @@ void test_read_ccd_file_handle_spaces() {
 
     struct Line_Data_Node* lines = read_ccd_file(file);
 
-    test_line("Handle Spaces", lines, "ver sion", "0 .1", 0);
+    test_line(__func__, __LINE__, lines, "ver sion", "0 .1", 0);
     printf("Indent: %d\n", lines->data->indentation);
     CU_ASSERT_PTR_NULL(lines->next);
 
@@ -87,16 +94,16 @@ void test_read_ccd_file_lowercase_left(){
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     printf("Beginning asserts\n");
-    test_line("Lowercase Left 0", lines, "lowercase left", "lowercase right", 0);
+    test_line(__func__, __LINE__, lines, "lowercase left", "lowercase right", 0);
     lines = lines->next;
 
-    test_line("Lowercase Left 1", lines, "lowercase left", "UpPeRcAsE right", 0);
+    test_line(__func__, __LINE__, lines, "lowercase left", "UpPeRcAsE right", 0);
     lines = lines->next;
 
-    test_line("Lowercase Left 2", lines, "uppercase left", "lowercase right", 0);
+    test_line(__func__, __LINE__, lines, "uppercase left", "lowercase right", 0);
     lines = lines->next;
 
-    test_line("Lowercase Left 3", lines, "uppercase left", "UpPeRcAsE right", 0);
+    test_line(__func__, __LINE__, lines, "uppercase left", "UpPeRcAsE right", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);
@@ -119,22 +126,22 @@ void test_trailing_whitespace_is_trimmed(){
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     printf("Beginning asserts\n");
-    test_line("Trim Trailing 0", lines, "nothing trailing", "nothing trailing", 0);
+    test_line(__func__, __LINE__, lines, "nothing trailing", "nothing trailing", 0);
     lines = lines->next;
 
-    test_line("Trim Trailing 1", lines, "trailing left", "nothing trailing", 0);
+    test_line(__func__, __LINE__, lines, "trailing left", "nothing trailing", 0);
     lines = lines->next;
 
-    test_line("Trim Trailing 2", lines, "nothing trailing", "trailing right", 0);
+    test_line(__func__, __LINE__, lines, "nothing trailing", "trailing right", 0);
     lines = lines->next;
 
-    test_line("Trim Trailing 3", lines, "trailing left", "trailing right", 0);
+    test_line(__func__, __LINE__, lines, "trailing left", "trailing right", 0);
     lines = lines->next;
     
-    test_line("Trim Trailing 4", lines, "empty right nothing trailing", "", 0);
+    test_line(__func__, __LINE__, lines, "empty right nothing trailing", "", 0);
     lines = lines->next;
 
-    test_line("Trim Trailing 5", lines, "empty right trailing left", "", 0);
+    test_line(__func__, __LINE__, lines, "empty right trailing left", "", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);
@@ -143,29 +150,40 @@ void test_trailing_whitespace_is_trimmed(){
 }
 
 void test_arbitrary_line_lengths(){
+    const char long_string = { [0 ... 99] = 'a', [100] = '\0'};
+
     FILE* file = tmpfile();
 
     fputs("short left:short right\n", file);
-    fputs("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:short right\n", file);
-    fputs("short left:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n", file);
-    fputs("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n", file);
-
+    // "a...a:short right"
+    fputs(long_string, file);
+    fputs(":short right\n", file);
+    // "short left:a...a"
+    fputs("short left:", file);
+    fputs(long_string, file);
+    fputs("\n", file);
+    // "a...a:a...a"
+    fputs(long_string, file);
+    fputs(":", file);
+    fputs(long_string, file);
+    fputs("\n", file);
+    
     rewind(file);
 
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     // Remember, left side will be lowercase
     printf("Beginning asserts\n");
-    test_line("Arbitrary Length 0", lines, "short left", "short right", 0);
+    test_line(__func__, __LINE__, lines, "short left", "short right", 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 1", lines, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "short right", 0);
+    test_line(__func__, __LINE__, lines, long_string, "short right", 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 2", lines, "short left", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 0);
+    test_line(__func__, __LINE__, lines, "short left", long_string, 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 3", lines, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 0);
+    test_line(__func__, __LINE__, lines, long_string, long_string, 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);
@@ -174,6 +192,7 @@ void test_arbitrary_line_lengths(){
 }
 
 void add_data_reader_tests(CU_pSuite test_suite) {
+    failed_tests_ptr = &CU_get_registry()->uiNumberOfTests;
     CU_ADD_TEST(test_suite, test_read_ccd_file);
     CU_ADD_TEST(test_suite, test_read_ccd_file_handle_spaces);
     CU_ADD_TEST(test_suite, test_read_ccd_file_lowercase_left);

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -150,7 +150,8 @@ void test_trailing_whitespace_is_trimmed(){
 }
 
 void test_arbitrary_line_lengths(){
-    const char long_string = { [0 ... 99] = 'a', [100] = '\0'};
+    char long_string = { [0 ... 99] = 'a'};
+    long_string[99] = '\0';
 
     FILE* file = tmpfile();
 

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -8,7 +8,8 @@
 #include <string.h>
 
 // Generic function to test a whole line
-void test_line(struct Line_Data_Node* lines, char expected_left[], char expected_right[], int expected_indentation){
+void test_line(char source_line[], struct Line_Data_Node* lines, char expected_left[], char expected_right[], int expected_indentation){
+    printf("%s\n", source_line); // The generic function is too abstract without this
     CU_ASSERT_PTR_NOT_NULL(lines);
     CU_ASSERT_PTR_NOT_NULL(lines->data);
     CU_ASSERT(strcmp(lines->data->left, expected_left) == 0);
@@ -32,22 +33,22 @@ void test_read_ccd_file(){
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     printf("Beginning asserts\n");
-    test_line(lines, "version", "0.1", 0);
+    test_line("Read CCD File 0", lines, "version", "0.1", 0);
     lines = lines->next;
 
-    test_line(lines, "type", "class", 0);
+    test_line("Read CCD File 1", lines, "type", "class", 0);
     lines = lines->next;
 
-    test_line(lines, "name", "test", 0);
+    test_line("Read CCD File 2", lines, "name", "test", 0);
     lines = lines->next;
 
-    test_line(lines, "fields", "", 0);
+    test_line("Read CCD File 3", lines, "fields", "", 0);
     lines = lines->next;
 
-    test_line(lines, "test_field", "", 4);
+    test_line("Read CCD File 4", lines, "test_field", "", 4);
     lines = lines->next;
 
-    test_line(lines, "type", "int32", 8);
+    test_line("Read CCD File 5", lines, "type", "int32", 8);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);
@@ -64,7 +65,7 @@ void test_read_ccd_file_handle_spaces() {
 
     struct Line_Data_Node* lines = read_ccd_file(file);
 
-    test_line(lines, "ver sion", "0 .1", 0);
+    test_line("Handle Spaces", lines, "ver sion", "0 .1", 0);
     printf("Indent: %d\n", lines->data->indentation);
     CU_ASSERT_PTR_NULL(lines->next);
 
@@ -86,16 +87,16 @@ void test_read_ccd_file_lowercase_left(){
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     printf("Beginning asserts\n");
-    test_line(lines, "lowercase left", "lowercase right", 0);
+    test_line("Lowercase Left 0", lines, "lowercase left", "lowercase right", 0);
     lines = lines->next;
 
-    test_line(lines, "lowercase left", "UpPeRcAsE right", 0);
+    test_line("Lowercase Left 1", lines, "lowercase left", "UpPeRcAsE right", 0);
     lines = lines->next;
 
-    test_line(lines, "uppercase left", "lowercase right", 0);
+    test_line("Lowercase Left 2", lines, "uppercase left", "lowercase right", 0);
     lines = lines->next;
 
-    test_line(lines, "uppercase left", "UpPeRcAsE right", 0);
+    test_line("Lowercase Left 3", lines, "uppercase left", "UpPeRcAsE right", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);
@@ -118,22 +119,22 @@ void test_trailing_whitespace_is_trimmed(){
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     printf("Beginning asserts\n");
-    test_line(lines, "nothing trailing", "nothing trailing", 0);
+    test_line("Trim Trailing 0", lines, "nothing trailing", "nothing trailing", 0);
     lines = lines->next;
 
-    test_line(lines, "trailing left", "nothing trailing", 0);
+    test_line("Trim Trailing 1", lines, "trailing left", "nothing trailing", 0);
     lines = lines->next;
 
-    test_line(lines, "nothing trailing", "trailing right", 0);
+    test_line("Trim Trailing 2", lines, "nothing trailing", "trailing right", 0);
     lines = lines->next;
 
-    test_line(lines, "trailing left", "trailing right", 0);
+    test_line("Trim Trailing 3", lines, "trailing left", "trailing right", 0);
     lines = lines->next;
     
-    test_line(lines, "empty right nothing trailing", "", 0);
+    test_line("Trim Trailing 4", lines, "empty right nothing trailing", "", 0);
     lines = lines->next;
 
-    test_line(lines, "empty right trailing left", "", 0);
+    test_line("Trim Trailing 5", lines, "empty right trailing left", "", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);
@@ -154,16 +155,16 @@ void test_arbitrary_line_lengths(){
     struct Line_Data_Node* lines = read_ccd_file(file);
 
     printf("Beginning asserts\n");
-    test_line(lines, "short left", "short right", 0);
+    test_line("Arbitrary Length 0", lines, "short left", "short right", 0);
     lines = lines->next;
 
-    test_line(lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
+    test_line("Arbitrary Length 1", lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
     lines = lines->next;
 
-    test_line(lines, "short left", "I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths", 0);
+    test_line("Arbitrary Length 2", lines, "short left", "I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths", 0);
     lines = lines->next;
 
-    test_line(lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
+    test_line("Arbitrary Length 3", lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -150,23 +150,22 @@ void test_trailing_whitespace_is_trimmed(){
 }
 
 void test_arbitrary_line_lengths(){
-    char long_string = { [0 ... 99] = 'a'};
-    long_string[99] = '\0';
+    const char long_string[] = { [0 ... 99] = 'a', [100] = '\0'};
 
     FILE* file = tmpfile();
 
     fputs("short left:short right\n", file);
     // "a...a:short right"
-    fputs(*long_string, file);
+    fputs(long_string, file);
     fputs(":short right\n", file);
     // "short left:a...a"
     fputs("short left:", file);
-    fputs(*long_string, file);
+    fputs(long_string, file);
     fputs("\n", file);
     // "a...a:a...a"
-    fputs(*long_string, file);
+    fputs(long_string, file);
     fputs(":", file);
-    fputs(*long_string, file);
+    fputs(long_string, file);
     fputs("\n", file);
     
     rewind(file);
@@ -178,13 +177,13 @@ void test_arbitrary_line_lengths(){
     test_line(__func__, __LINE__, lines, "short left", "short right", 0);
     lines = lines->next;
 
-    test_line(__func__, __LINE__, lines, *long_string, "short right", 0);
+    test_line(__func__, __LINE__, lines, long_string, "short right", 0);
     lines = lines->next;
 
-    test_line(__func__, __LINE__, lines, "short left", *long_string, 0);
+    test_line(__func__, __LINE__, lines, "short left", long_string, 0);
     lines = lines->next;
 
-    test_line(__func__, __LINE__, lines, *long_string, *long_string, 0);
+    test_line(__func__, __LINE__, lines, long_string, long_string, 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -158,13 +158,13 @@ void test_arbitrary_line_lengths(){
     test_line("Arbitrary Length 0", lines, "short left", "short right", 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 1", lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
+    //test_line("Arbitrary Length 1", lines, "I am a very long left side, and I could contain some pointless string that is just very long, but I think I'd be more useful if I contained a lot of descriptive text about what I am, and my punctuation is not a concern cos I said so", "short right", 0);
     lines = lines->next;
 
     test_line("Arbitrary Length 2", lines, "short left", "I should be able to be extra long on either side of the colon, and I'm sorry if this makes the test a bit unreadable, but it should illustrate the point that is trying to be made that the data reader can handle really long line lengths", 0);
     lines = lines->next;
 
-    test_line("Arbitrary Length 3", lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
+    //test_line("Arbitrary Length 3", lines, "I'm not going to be as long as my friend two lines above, but I will be quite long", "As I use the other side of the colon to continue to be a very very long line overall", 0);
     CU_ASSERT_PTR_NULL(lines->next);
 
     delete_list(lines);

--- a/tests/data_reader_tests/data_reader_tests.c
+++ b/tests/data_reader_tests/data_reader_tests.c
@@ -8,10 +8,10 @@
 #include <string.h>
 
 int known_failed_tests = 0;
-int* failed_tests_ptr;
+const int* failed_tests_ptr;
 
 // Generic function to test a whole line
-void test_line(const char source_func[], const int source_line, struct Line_Data_Node* lines, char expected_left[], char expected_right[], int expected_indentation){
+void test_line(const char source_func[], const int source_line, struct Line_Data_Node* lines, const char expected_left[], const char expected_right[], int expected_indentation){
     CU_ASSERT_PTR_NOT_NULL(lines);
     CU_ASSERT_PTR_NOT_NULL(lines->data);
     CU_ASSERT(strcmp(lines->data->left, expected_left) == 0);


### PR DESCRIPTION
Modified data_reader.c to peek through the input stream until it encounters a "\n", counting the line length as it does.

Further modification to check for ":" to count the number of characters on the left and right of the ":", ensuring the line_data->left and line_data->right only take up the memory they require.
(current implementation reserves twice the length of the line, once for each attribute)